### PR TITLE
[FEAT] `oauth/code` API 추가 (소셜 로그인)

### DIFF
--- a/src/main/java/com/ecolink/core/auth/domain/SocialAvatarCreateRequest.java
+++ b/src/main/java/com/ecolink/core/auth/domain/SocialAvatarCreateRequest.java
@@ -1,0 +1,39 @@
+package com.ecolink.core.auth.domain;
+
+import com.ecolink.core.avatar.domain.AvatarCreateRequest;
+import com.ecolink.core.avatar.domain.ProfilePhoto;
+import com.ecolink.core.user.domain.User;
+
+public class SocialAvatarCreateRequest implements AvatarCreateRequest {
+
+	private final String nickname;
+	private final User user;
+	private final ProfilePhoto photo;
+
+	public SocialAvatarCreateRequest(String nickname, User user, ProfilePhoto photo) {
+		this.nickname = nickname;
+		this.user = user;
+		this.photo = photo;
+	}
+
+	public static AvatarCreateRequest of(String nickname, User user, ProfilePhoto photo) {
+		return new SocialAvatarCreateRequest(nickname, user, photo);
+	}
+
+	@Override
+	public String nickname() {
+		return this.nickname;
+	}
+
+	@Override
+	public User user() {
+		return this.user;
+	}
+
+	@Override
+	public ProfilePhoto photo() {
+		return this.photo;
+	}
+
+
+}

--- a/src/main/java/com/ecolink/core/auth/domain/SocialUserCreateRequest.java
+++ b/src/main/java/com/ecolink/core/auth/domain/SocialUserCreateRequest.java
@@ -1,0 +1,56 @@
+package com.ecolink.core.auth.domain;
+
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.user.constant.Password;
+import com.ecolink.core.user.constant.UserType;
+import com.ecolink.core.user.domain.Role;
+import com.ecolink.core.user.domain.UserCreateRequest;
+
+public class SocialUserCreateRequest implements UserCreateRequest {
+
+	private final String name;
+	private final String email;
+	private final UserType userType;
+	private final Role role;
+
+	public SocialUserCreateRequest(String name, String email, UserType userType, Role role) {
+		this.name = name;
+		this.email = email;
+		this.userType = userType;
+		this.role = role;
+	}
+
+	public static SocialUserCreateRequest of(OAuth2Attributes attributes, Role role) {
+		return new SocialUserCreateRequest(
+			attributes.getName(),
+			attributes.getEmail(),
+			attributes.getUserType(),
+			role
+		);
+	}
+
+	@Override
+	public String email() {
+		return this.email;
+	}
+
+	@Override
+	public String name() {
+		return this.name;
+	}
+
+	@Override
+	public UserType userType() {
+		return this.userType;
+	}
+
+	@Override
+	public Role role() {
+		return this.role;
+	}
+
+	@Override
+	public Password password() {
+		return null;
+	}
+}

--- a/src/main/java/com/ecolink/core/auth/dto/AuthenticationResult.java
+++ b/src/main/java/com/ecolink/core/auth/dto/AuthenticationResult.java
@@ -1,0 +1,18 @@
+package com.ecolink.core.auth.dto;
+
+import com.ecolink.core.auth.dto.response.AuthenticationResponse;
+import com.ecolink.core.auth.token.AuthenticationToken;
+
+import lombok.Getter;
+
+@Getter
+public class AuthenticationResult {
+
+	private final AuthenticationToken token;
+	private final AuthenticationResponse response;
+
+	public AuthenticationResult(AuthenticationToken token, AuthenticationResponse response) {
+		this.token = token;
+		this.response = response;
+	}
+}

--- a/src/main/java/com/ecolink/core/auth/dto/response/AuthenticationResponse.java
+++ b/src/main/java/com/ecolink/core/auth/dto/response/AuthenticationResponse.java
@@ -1,0 +1,38 @@
+package com.ecolink.core.auth.dto.response;
+
+import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.common.domain.ImageFile;
+import com.ecolink.core.user.constant.UserType;
+import com.ecolink.core.user.domain.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AuthenticationResponse {
+
+	private final String email;
+	private final String nickname;
+	private final ImageFile profilePhoto;
+	private final Boolean isNewUser;
+	private final UserType type;
+
+	private AuthenticationResponse(String email, UserType type, String nickname, ImageFile profilePhoto,
+		boolean isNewUser) {
+		this.email = email;
+		this.type = type;
+		this.nickname = nickname;
+		this.profilePhoto = profilePhoto;
+		this.isNewUser = isNewUser;
+	}
+
+	public static AuthenticationResponse of(User user, Avatar avatar, boolean newUser) {
+		return new AuthenticationResponse(user.getEmail(), user.getUserType(), avatar.getNickname(),
+			avatar.getPhoto().getFile(), newUser);
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ecolink/core/auth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,60 @@
+package com.ecolink.core.auth.handler;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.ecolink.core.auth.dto.AuthenticationResult;
+import com.ecolink.core.auth.dto.response.AuthenticationResponse;
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.auth.service.AuthenticationService;
+import com.ecolink.core.auth.service.SecurityContextService;
+import com.ecolink.core.common.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+	private final SecurityContextService securityContextService;
+	private final AuthenticationService authenticationService;
+	private final ObjectMapper mapper;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+		OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken)authentication;
+
+		OAuth2Attributes attributes = OAuth2Attributes.of(oauth2Token.getPrincipal().getAttributes());
+		AuthenticationResult result = authenticationService.oauthSignIn(attributes, request);
+		log.info("User signed in: {}", result.getResponse());
+		securityContextService.saveToSecurityContext(result.getToken());
+		responseDto(response, result.getResponse());
+	}
+
+	private void responseDto(HttpServletResponse response, AuthenticationResponse dto) throws IOException {
+		String convertedDto = mapper.writeValueAsString(ApiResponse.ok(dto));
+
+		response.setStatus(HttpStatus.ACCEPTED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+
+		PrintWriter writer = response.getWriter();
+		writer.write(convertedDto);
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/model/OAuth2Attributes.java
+++ b/src/main/java/com/ecolink/core/auth/model/OAuth2Attributes.java
@@ -1,0 +1,50 @@
+package com.ecolink.core.auth.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.ecolink.core.user.constant.UserType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuth2Attributes {
+
+	private Map<String, Object> attributes;
+	private UserType userType;
+	private String attributeKey;
+	private String email;
+	private String name;
+	private boolean hasImage;
+	private String profileImage;
+
+	public static OAuth2Attributes of(Map<String, Object> attributes) {
+		return OAuth2Attributes.builder()
+			.userType((UserType)attributes.get("userType"))
+			.attributeKey((String)attributes.get("key"))
+			.email((String)attributes.get("email"))
+			.name((String)attributes.get("name"))
+			.hasImage((Boolean)attributes.get("hasImage"))
+			.profileImage((String)attributes.get("profileImage"))
+			.build();
+	}
+
+	public Map<String, Object> convertToMap() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("userType", userType);
+		map.put("id", attributeKey);
+		map.put("key", attributeKey);
+		map.put("email", email);
+		map.put("name", name);
+		map.put("hasImage", hasImage);
+		map.put("profileImage", profileImage);
+		return map;
+	}
+
+	public boolean hasImage() {
+		return this.hasImage;
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/service/AuthenticationService.java
+++ b/src/main/java/com/ecolink/core/auth/service/AuthenticationService.java
@@ -1,0 +1,48 @@
+package com.ecolink.core.auth.service;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.auth.dto.response.AuthenticationResponse;
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.auth.token.AuthenticationToken;
+import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.common.error.ErrorCode;
+import com.ecolink.core.common.error.exception.DuplicatedEmailException;
+import com.ecolink.core.user.domain.User;
+import com.ecolink.core.auth.dto.AuthenticationResult;
+import com.ecolink.core.user.service.SignUpService;
+import com.ecolink.core.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthenticationService {
+
+	private final UserService userService;
+	private final SignUpService signUpService;
+	private final AvatarSelectStrategy avatarSelectStrategy;
+
+	@Transactional
+	public AuthenticationResult oauthSignIn(OAuth2Attributes attributes, HttpServletRequest request) {
+		Optional<User> optionalUser = userService.getOptionalByEmail(attributes.getEmail());
+		boolean isNewUser = optionalUser.isEmpty();
+		User user = optionalUser.orElseGet(() -> signUpService.signUp(attributes));
+
+		if (!isNewUser && !user.isUserOf(attributes.getUserType()))
+			throw new DuplicatedEmailException(ErrorCode.EMAIL_IS_REGISTER_WITH_ANOTHER_PROVIDER,
+				attributes.getUserType(), user.getUserType());
+
+		Avatar avatar = avatarSelectStrategy.select(user, request);
+
+		return new AuthenticationResult(
+			AuthenticationToken.of(user, avatar, Set.of(user.getRole().toGrantedAuthority())),
+			AuthenticationResponse.of(user, avatar, isNewUser));
+	}
+}

--- a/src/main/java/com/ecolink/core/auth/service/AvatarSelectStrategy.java
+++ b/src/main/java/com/ecolink/core/auth/service/AvatarSelectStrategy.java
@@ -1,0 +1,12 @@
+package com.ecolink.core.auth.service;
+
+import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.user.domain.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface AvatarSelectStrategy {
+
+	Avatar select(User user, HttpServletRequest request);
+
+}

--- a/src/main/java/com/ecolink/core/auth/service/OAuth2RequestService.java
+++ b/src/main/java/com/ecolink/core/auth/service/OAuth2RequestService.java
@@ -32,7 +32,7 @@ public class OAuth2RequestService {
 
 	public OAuth2StateResponse createRequest(HttpServletRequest request, HttpServletResponse response, String provider) {
 		if(clientRegistrationRepository.findByRegistrationId(provider) == null)
-			throw new InvalidProviderException(ErrorCode.INVALID_PROVIDER);
+			throw new InvalidProviderException(ErrorCode.UNREGISTERED_PROVIDER);
 
 		// OAuth 인가 요청을 생성
 		OAuth2AuthorizationRequest oAuth2AuthorizationRequest = oAuth2AuthorizationRequestResolver.resolve(request,

--- a/src/main/java/com/ecolink/core/auth/service/OAuth2UserLoadingService.java
+++ b/src/main/java/com/ecolink/core/auth/service/OAuth2UserLoadingService.java
@@ -1,0 +1,36 @@
+package com.ecolink.core.auth.service;
+
+import java.util.List;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.user.constant.UserType;
+
+@Service
+public class OAuth2UserLoadingService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		String userNameAttributeName = userRequest.getClientRegistration()
+			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+		UserType type = UserType.fromString(registrationId)
+			.orElseThrow(() -> new IllegalArgumentException("정의되지 않은 프로바이더가 입력되었습니다."));
+
+		OAuth2Attributes attributes = type.extract(userNameAttributeName, oAuth2User.getAttributes());
+
+		return new DefaultOAuth2User(List.of(), attributes.convertToMap(), "email");
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/service/OAuth2UserLoadingService.java
+++ b/src/main/java/com/ecolink/core/auth/service/OAuth2UserLoadingService.java
@@ -11,6 +11,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.common.error.ErrorCode;
+import com.ecolink.core.common.error.exception.InvalidProviderException;
 import com.ecolink.core.user.constant.UserType;
 
 @Service
@@ -26,7 +28,7 @@ public class OAuth2UserLoadingService implements OAuth2UserService<OAuth2UserReq
 		String userNameAttributeName = userRequest.getClientRegistration()
 			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 		UserType type = UserType.fromString(registrationId)
-			.orElseThrow(() -> new IllegalArgumentException("정의되지 않은 프로바이더가 입력되었습니다."));
+			.orElseThrow(() -> new InvalidProviderException(ErrorCode.UNDEFINED_PROVIDER));
 
 		OAuth2Attributes attributes = type.extract(userNameAttributeName, oAuth2User.getAttributes());
 

--- a/src/main/java/com/ecolink/core/auth/service/SecurityContextService.java
+++ b/src/main/java/com/ecolink/core/auth/service/SecurityContextService.java
@@ -1,0 +1,56 @@
+package com.ecolink.core.auth.service;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class SecurityContextService {
+
+	private final SecurityContextHolderStrategy securityContextHolderStrategy =
+		SecurityContextHolder.getContextHolderStrategy();
+
+	private final SecurityContextRepository securityContextRepository =
+		new HttpSessionSecurityContextRepository();
+
+	public void saveToSecurityContext(AbstractAuthenticationToken authenticationToken) {
+		saveToSecurityContext(getRequest(), getResponse(), authenticationToken);
+	}
+
+	public void saveToSecurityContext(HttpServletRequest request, HttpServletResponse response,
+		AbstractAuthenticationToken authenticationToken) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(authenticationToken);
+		securityContextHolderStrategy.setContext(context);
+		securityContextRepository.saveContext(context, request, response);
+	}
+
+	private static HttpServletRequest getRequest() {
+		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+		if (requestAttributes instanceof ServletRequestAttributes attributes) {
+			return attributes.getRequest();
+		}
+		return null;
+	}
+
+	private static HttpServletResponse getResponse() {
+		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+		if (requestAttributes instanceof ServletRequestAttributes attributes) {
+			return attributes.getResponse();
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/service/SingleAvatarSelectStrategy.java
+++ b/src/main/java/com/ecolink/core/auth/service/SingleAvatarSelectStrategy.java
@@ -1,0 +1,17 @@
+package com.ecolink.core.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.user.domain.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Service
+public class SingleAvatarSelectStrategy implements AvatarSelectStrategy {
+
+	@Override
+	public Avatar select(User user, HttpServletRequest request) {
+		return user.getAvatars().get(0);
+	}
+}

--- a/src/main/java/com/ecolink/core/auth/token/AuthenticationToken.java
+++ b/src/main/java/com/ecolink/core/auth/token/AuthenticationToken.java
@@ -19,7 +19,7 @@ public class AuthenticationToken extends AbstractAuthenticationToken {
 		this.principal = principal;
 	}
 
-	public static AuthenticationToken of(User user, Avatar avatar, Set<SimpleGrantedAuthority> authorities) {
+	public static AuthenticationToken of(User user, Avatar avatar, Set<? extends GrantedAuthority> authorities) {
 		return new AuthenticationToken(UserPrincipal.of(user, avatar, authorities), authorities);
 	}
 
@@ -51,4 +51,5 @@ public class AuthenticationToken extends AbstractAuthenticationToken {
 		result = 31 * result + principal.hashCode();
 		return result;
 	}
+
 }

--- a/src/main/java/com/ecolink/core/auth/token/UserPrincipal.java
+++ b/src/main/java/com/ecolink/core/auth/token/UserPrincipal.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Set;
 
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
 
 import com.ecolink.core.avatar.domain.Avatar;
 import com.ecolink.core.user.constant.UserType;
@@ -36,9 +36,9 @@ public class UserPrincipal implements Serializable {
 	private String nickname;
 
 	// Role
-	private final Set<SimpleGrantedAuthority> authorities;
+	private final Set<? extends GrantedAuthority> authorities;
 
-	public static UserPrincipal of(User user, Avatar avatar, Set<SimpleGrantedAuthority> authoritySet) {
+	public static UserPrincipal of(User user, Avatar avatar, Set<? extends GrantedAuthority> authoritySet) {
 		return UserPrincipal.builder()
 			.userId(user.getId())
 			.email(user.getEmail())

--- a/src/main/java/com/ecolink/core/avatar/domain/Avatar.java
+++ b/src/main/java/com/ecolink/core/avatar/domain/Avatar.java
@@ -3,6 +3,7 @@ package com.ecolink.core.avatar.domain;
 import com.ecolink.core.common.domain.BaseTimeEntity;
 import com.ecolink.core.user.domain.User;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,10 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,18 +27,35 @@ public class Avatar extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(unique = true)
 	@NotNull
 	@Size(min = 4, max = 12)
 	private String nickname;
-
-	private String introduction;
 
 	@NotNull
 	@JoinColumn(name = "user_id")
 	@ManyToOne(fetch = FetchType.LAZY)
 	private User user;
 
-	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "photo_id")
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProfilePhoto photo;
+
+	@Builder
+	private Avatar(String nickname, User user, ProfilePhoto photo) {
+		this.nickname = nickname;
+		this.user = user;
+		this.photo = photo;
+	}
+
+	public static Avatar of(AvatarCreateRequest request) {
+		Avatar avatar = Avatar.builder()
+			.nickname(request.nickname())
+			.user(request.user())
+			.photo(request.photo())
+			.build();
+		request.user().addAvatar(avatar);
+		return avatar;
+	}
+
 }

--- a/src/main/java/com/ecolink/core/avatar/domain/AvatarCreateRequest.java
+++ b/src/main/java/com/ecolink/core/avatar/domain/AvatarCreateRequest.java
@@ -1,0 +1,13 @@
+package com.ecolink.core.avatar.domain;
+
+import com.ecolink.core.user.domain.User;
+
+public interface AvatarCreateRequest {
+
+	String nickname();
+
+	User user();
+
+	ProfilePhoto photo();
+
+}

--- a/src/main/java/com/ecolink/core/avatar/domain/ProfilePhoto.java
+++ b/src/main/java/com/ecolink/core/avatar/domain/ProfilePhoto.java
@@ -28,4 +28,8 @@ public class ProfilePhoto extends BaseTimeEntity {
 	@Embedded
 	private ImageFile file;
 
+	public ProfilePhoto(ImageFile file) {
+		this.file = file;
+	}
+
 }

--- a/src/main/java/com/ecolink/core/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/ecolink/core/avatar/repository/AvatarRepository.java
@@ -10,6 +10,10 @@ import com.ecolink.core.avatar.domain.Avatar;
 
 public interface AvatarRepository extends JpaRepository<Avatar, Long> {
 
+	@Query("select (count(a) > 0) from Avatar a "
+		+ "where a.nickname = :nickname")
+	boolean existsByNickname(@Param("nickname") String nickname);
+
 	@Query("select a from Avatar a "
 		+ "join fetch a.photo p "
 		+ "join fetch a.user u "

--- a/src/main/java/com/ecolink/core/avatar/repository/ProfilePhotoRepository.java
+++ b/src/main/java/com/ecolink/core/avatar/repository/ProfilePhotoRepository.java
@@ -1,0 +1,8 @@
+package com.ecolink.core.avatar.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ecolink.core.avatar.domain.ProfilePhoto;
+
+public interface ProfilePhotoRepository extends JpaRepository<ProfilePhoto, Long> {
+}

--- a/src/main/java/com/ecolink/core/avatar/service/AvatarService.java
+++ b/src/main/java/com/ecolink/core/avatar/service/AvatarService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.avatar.domain.AvatarCreateRequest;
 import com.ecolink.core.avatar.repository.AvatarRepository;
 import com.ecolink.core.common.error.ErrorCode;
 import com.ecolink.core.common.error.exception.EntityNotFoundException;
@@ -25,6 +26,11 @@ public class AvatarService {
 	public Avatar getUserGraphById(Long avatarId) {
 		return avatarRepository.findUserGraphById(avatarId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.AVATAR_NOT_FOUND));
+	}
+
+	@Transactional
+	public Avatar createAvatar(AvatarCreateRequest request) {
+		return avatarRepository.save(Avatar.of(request));
 	}
 
 }

--- a/src/main/java/com/ecolink/core/avatar/service/NicknameService.java
+++ b/src/main/java/com/ecolink/core/avatar/service/NicknameService.java
@@ -1,0 +1,42 @@
+package com.ecolink.core.avatar.service;
+
+import java.util.List;
+import java.util.Random;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.avatar.repository.AvatarRepository;
+import com.ecolink.core.common.error.ErrorCode;
+import com.ecolink.core.common.error.exception.NicknameSelectFailException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NicknameService {
+
+	private static final List<String> WORDS = List.of("세글자");
+	private static final Random RANDOM = new Random();
+
+	private final AvatarRepository avatarRepository;
+
+	public String getUniqueRandomNickname() {
+		String nickname;
+		int count = 0;
+		do {
+			String pre = WORDS.get(RANDOM.nextInt(WORDS.size()));
+			String post = RandomStringUtils.randomAlphanumeric(4);
+			nickname = pre + post;
+			if (count++ > 10)
+				throw new NicknameSelectFailException(ErrorCode.FAIL_TO_FIND_UNIQUE_NICKNAME);
+		} while (isNicknameInUse(nickname));
+		return nickname;
+	}
+
+	public boolean isNicknameInUse(String nickname) {
+		return avatarRepository.existsByNickname(nickname);
+	}
+}

--- a/src/main/java/com/ecolink/core/avatar/service/ProfilePhotoService.java
+++ b/src/main/java/com/ecolink/core/avatar/service/ProfilePhotoService.java
@@ -1,0 +1,31 @@
+package com.ecolink.core.avatar.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.avatar.domain.ProfilePhoto;
+import com.ecolink.core.avatar.repository.ProfilePhotoRepository;
+import com.ecolink.core.common.domain.ImageFile;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ProfilePhotoService {
+
+	private static final String DEFAULT_PROFILE_PHOTO_URL = "https://k.kakaocdn.net/dn/1G9kp/btsAot8liOn/8CWudi3uy07rvFNUkk3ER0/img_640x640.jpg";
+	private final ProfilePhotoRepository profilePhotoRepository;
+
+	@Transactional
+	public ProfilePhoto getInitialPhoto(OAuth2Attributes attributes) {
+		return profilePhotoRepository.save(new ProfilePhoto(getImageFile(attributes)));
+	}
+
+	private ImageFile getImageFile(OAuth2Attributes attributes) {
+		if (attributes.hasImage())
+			return ImageFile.externalImage(attributes.getProfileImage());
+		return ImageFile.externalImage(DEFAULT_PROFILE_PHOTO_URL);
+	}
+}

--- a/src/main/java/com/ecolink/core/common/domain/ImageFile.java
+++ b/src/main/java/com/ecolink/core/common/domain/ImageFile.java
@@ -1,5 +1,10 @@
 package com.ecolink.core.common.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -8,20 +13,34 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Embeddable
 public class ImageFile {
 
 	@NotNull
 	private String url;
 
-	@NotNull
+	@JsonIgnore
 	private String s3Key;
 
-	@NotNull
+	@JsonIgnore
 	private Long byteSize;
 
 	private Integer width;
 
 	private Integer height;
+
+	private ImageFile(String url, String s3Key, Long byteSize, Integer width, Integer height) {
+		this.url = url;
+		this.s3Key = s3Key;
+		this.byteSize = byteSize;
+		this.width = width;
+		this.height = height;
+	}
+
+	public static ImageFile externalImage(String url) {
+		return new ImageFile(url, null, null, null, null);
+	}
 
 }

--- a/src/main/java/com/ecolink/core/common/error/ErrorCode.java
+++ b/src/main/java/com/ecolink/core/common/error/ErrorCode.java
@@ -22,8 +22,9 @@ public enum ErrorCode {
 	/**
 	 * 인증 관련 오류
 	 */
-	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "OA-001", "유효하지 않은 provider입니다."),
+	UNREGISTERED_PROVIDER(HttpStatus.BAD_REQUEST, "OA-001", "등록되지 않은 프로바이더가 입력되었습니다."),
 	EMAIL_IS_REGISTER_WITH_ANOTHER_PROVIDER(HttpStatus.BAD_REQUEST, "OA-002", "같은 이메일이 다른 소셜 로그인 플랫폼으로 가입되어 있습니다."),
+	UNDEFINED_PROVIDER(HttpStatus.INTERNAL_SERVER_ERROR, "OA-003", "유저타입에 정의되지 않은 프로바이더가 입력되었습니다."),
 
 	/**
 	 * 닉네임 관련 오류

--- a/src/main/java/com/ecolink/core/common/error/ErrorCode.java
+++ b/src/main/java/com/ecolink/core/common/error/ErrorCode.java
@@ -22,9 +22,16 @@ public enum ErrorCode {
 	/**
 	 * 인증 관련 오류
 	 */
-	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "OA-001", "유효하지 않은 provider입니다.");
+	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "OA-001", "유효하지 않은 provider입니다."),
+	EMAIL_IS_REGISTER_WITH_ANOTHER_PROVIDER(HttpStatus.BAD_REQUEST, "OA-002", "같은 이메일이 다른 소셜 로그인 플랫폼으로 가입되어 있습니다."),
+
+	/**
+	 * 닉네임 관련 오류
+	 */
+	FAIL_TO_FIND_UNIQUE_NICKNAME(HttpStatus.INTERNAL_SERVER_ERROR, "N-001", "유일한 닉네임을 찾는데 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;
 	private final String message;
+
 }

--- a/src/main/java/com/ecolink/core/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ecolink/core/common/error/GlobalExceptionHandler.java
@@ -11,11 +11,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.ecolink.core.common.error.exception.DuplicatedEmailException;
 import com.ecolink.core.common.response.ErrorResponse;
+import com.ecolink.core.user.constant.UserType;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
 
 	@ExceptionHandler(value = Exception.class)
 	public ResponseEntity<ErrorResponse<Object>> handleException(Exception e) {
@@ -59,6 +60,18 @@ public class GlobalExceptionHandler {
 		ErrorCode errorCode = e.getErrorCode();
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	/**
+	 * 소셜 로그인시 다른 프로바이더에서 해당 이메일로 가입했을 경우 발생하는 예외
+	 */
+	@ExceptionHandler(value = DuplicatedEmailException.class)
+	public ResponseEntity<ErrorResponse<UserType>> handleDuplicatedEmailException(DuplicatedEmailException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		Map<String, UserType> data = Map.of("requestedType", e.getRequestedType(), "existingType", e.getExistingType());
+
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.error(data, errorCode.getCode(), errorCode.getMessage()));
 	}
 
 }

--- a/src/main/java/com/ecolink/core/common/error/exception/DuplicatedEmailException.java
+++ b/src/main/java/com/ecolink/core/common/error/exception/DuplicatedEmailException.java
@@ -1,0 +1,21 @@
+package com.ecolink.core.common.error.exception;
+
+import com.ecolink.core.common.error.ErrorCode;
+import com.ecolink.core.common.error.GeneralException;
+import com.ecolink.core.user.constant.UserType;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicatedEmailException extends GeneralException {
+
+	private final UserType requestedType;
+	private final UserType existingType;
+
+	public DuplicatedEmailException(ErrorCode errorCode, UserType requestedType, UserType existingType) {
+		super(errorCode);
+		this.requestedType = requestedType;
+		this.existingType = existingType;
+	}
+
+}

--- a/src/main/java/com/ecolink/core/common/error/exception/NicknameSelectFailException.java
+++ b/src/main/java/com/ecolink/core/common/error/exception/NicknameSelectFailException.java
@@ -1,0 +1,10 @@
+package com.ecolink.core.common.error.exception;
+
+import com.ecolink.core.common.error.ErrorCode;
+import com.ecolink.core.common.error.GeneralException;
+
+public class NicknameSelectFailException extends GeneralException {
+	public NicknameSelectFailException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/ecolink/core/common/response/ErrorResponse.java
+++ b/src/main/java/com/ecolink/core/common/response/ErrorResponse.java
@@ -2,10 +2,14 @@ package com.ecolink.core.common.response;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ErrorResponse<T> {
 
 	@Schema(description = "에러가 발생한 데이터")

--- a/src/main/java/com/ecolink/core/user/constant/UserType.java
+++ b/src/main/java/com/ecolink/core/user/constant/UserType.java
@@ -1,7 +1,68 @@
 package com.ecolink.core.user.constant;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.ecolink.core.auth.model.OAuth2Attributes;
+
 public enum UserType {
 
-	LOCAL, KAKAO, NAVER;
+	LOCAL("local") {
+		@Override
+		public OAuth2Attributes extract(String attributeKey, Map<String, Object> attributes) {
+			throw new AssertionError("잘못된 메서드 호출이 이루어졌습니다.");
+		}
+	},
+	KAKAO("kakao") {
+		@Override
+		public OAuth2Attributes extract(String attributeKey, Map<String, Object> attributes) {
+			Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+			Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+
+			return OAuth2Attributes.builder()
+				.attributes(attributes)
+				.userType(this)
+				.attributeKey(attributeKey)
+				.email((String)kakaoAccount.get("email"))
+				.name((String)kakaoProfile.get("nickname"))
+				.hasImage(!(Boolean)kakaoProfile.get("is_default_image"))
+				.profileImage((String)kakaoProfile.get("profile_image_url"))
+				.build();
+		}
+	},
+	NAVER("naver") {
+		@Override
+		public OAuth2Attributes extract(String attributeKey, Map<String, Object> attributes) {
+			return OAuth2Attributes.builder()
+				.attributes(attributes)
+				.userType(this)
+				.attributeKey(attributeKey)
+				.build();
+		}
+	};
+
+	private final String id;
+
+	UserType(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public String toString() {
+		return id;
+	}
+
+	public abstract OAuth2Attributes extract(String attributeKey, Map<String, Object> attributes);
+
+	private static final Map<String, UserType> stringToEnum =
+		Stream.of(values()).collect(toMap(Object::toString, e -> e));
+
+	// 지정한 문자열에 해당하는 `UserType`을 (존재한다면) 반환한다.
+	public static Optional<UserType> fromString(String id) {
+		return Optional.ofNullable(stringToEnum.get(id));
+	}
 
 }

--- a/src/main/java/com/ecolink/core/user/domain/Role.java
+++ b/src/main/java/com/ecolink/core/user/domain/Role.java
@@ -1,5 +1,8 @@
 package com.ecolink.core.user.domain;
 
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 import com.ecolink.core.user.constant.RoleType;
 
 import jakarta.persistence.Column;
@@ -28,8 +31,16 @@ public class Role {
 	@Enumerated(EnumType.STRING)
 	private RoleType type;
 
+	public Role(RoleType type) {
+		this.type = type;
+	}
+
 	public String getAuthority() {
 		return type.getAuthority();
+	}
+
+	public GrantedAuthority toGrantedAuthority() {
+		return new SimpleGrantedAuthority(getAuthority());
 	}
 
 }

--- a/src/main/java/com/ecolink/core/user/domain/User.java
+++ b/src/main/java/com/ecolink/core/user/domain/User.java
@@ -2,7 +2,12 @@ package com.ecolink.core.user.domain;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.springframework.util.Assert;
+
+import com.ecolink.core.avatar.domain.Avatar;
 import com.ecolink.core.common.domain.BaseTimeEntity;
 import com.ecolink.core.user.constant.Password;
 import com.ecolink.core.user.constant.RoleType;
@@ -19,8 +24,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -78,11 +85,57 @@ public class User extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Role role;
 
+	@OneToMany(mappedBy = "user")
+	private List<Avatar> avatars = new ArrayList<>();
+
+	@Builder
+	private User(String email, boolean locked, boolean expired, boolean withdrawn, boolean activated, String name,
+		UserType userType, Password password, Role role, LocalDate lastLoginDate) {
+		this.email = email;
+		this.locked = locked;
+		this.expired = expired;
+		this.withdrawn = withdrawn;
+		this.activated = activated;
+		this.name = name;
+		this.userType = userType;
+		this.password = password;
+		this.role = role;
+		this.lastLoginDate = lastLoginDate;
+	}
+
+	public static User createUser(UserCreateRequest request) {
+		Assert.hasText(request.email(), "이메일이 입력되지 않았습니다.");
+		Assert.hasText(request.name(), "이름이 입력되지 않았습니다");
+		Assert.notNull(request.userType(), "유저타입은 null일 수 없습니다.");
+		Assert.notNull(request.role(), "유저 권한(Role)은 최소한 1개는 부여되어야 합니다.");
+
+		return User.builder()
+			.email(request.email())
+			.name(request.name())
+			.userType(request.userType())
+			.password(request.password())
+			.activated(true)
+			.locked(false)
+			.expired(false)
+			.withdrawn(false)
+			.role(request.role())
+			.lastLoginDate(LocalDate.now())
+			.build();
+	}
+
 	/**
 	 * 영속성 컨텍스트에 Role 이 없을 경우 FetchType.LAZY 옵션 때문에 SELECT 쿼리가 나가게됨
 	 */
 	public boolean isManager() {
 		return RoleType.MANAGER.equals(this.role.getType());
+	}
+
+	public boolean isUserOf(UserType providerType) {
+		return providerType.equals(this.userType);
+	}
+
+	public void addAvatar(Avatar avatar) {
+		this.avatars.add(avatar);
 	}
 
 }

--- a/src/main/java/com/ecolink/core/user/domain/UserCreateRequest.java
+++ b/src/main/java/com/ecolink/core/user/domain/UserCreateRequest.java
@@ -1,0 +1,18 @@
+package com.ecolink.core.user.domain;
+
+import com.ecolink.core.user.constant.Password;
+import com.ecolink.core.user.constant.UserType;
+
+public interface UserCreateRequest {
+
+	String email();
+
+	String name();
+
+	UserType userType();
+
+	Role role();
+
+	Password password();
+
+}

--- a/src/main/java/com/ecolink/core/user/repository/RoleRepository.java
+++ b/src/main/java/com/ecolink/core/user/repository/RoleRepository.java
@@ -1,0 +1,16 @@
+package com.ecolink.core.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ecolink.core.user.constant.RoleType;
+import com.ecolink.core.user.domain.Role;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+	@Query("select r from Role r "
+		+ "where r.type = :type")
+	Optional<Role> findByType(@Param("type") RoleType type);
+}

--- a/src/main/java/com/ecolink/core/user/repository/UserRepository.java
+++ b/src/main/java/com/ecolink/core/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.ecolink.core.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ecolink.core.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	@Query("select u from User u "
+		+ "join fetch u.role "
+		+ "join fetch u.avatars a "
+		+ "join fetch a.photo p "
+		+ "where u.email = :email")
+	Optional<User> findByEmail(@Param("email") String email);
+
+}

--- a/src/main/java/com/ecolink/core/user/service/RoleService.java
+++ b/src/main/java/com/ecolink/core/user/service/RoleService.java
@@ -1,0 +1,24 @@
+package com.ecolink.core.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.user.constant.RoleType;
+import com.ecolink.core.user.domain.Role;
+import com.ecolink.core.user.repository.RoleRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RoleService {
+
+	private final RoleRepository roleRepository;
+
+	@Transactional
+	public Role getUserRole() {
+		return roleRepository.findByType(RoleType.USER)
+			.orElseGet(() -> roleRepository.save(new Role(RoleType.USER)));
+	}
+}

--- a/src/main/java/com/ecolink/core/user/service/SignUpService.java
+++ b/src/main/java/com/ecolink/core/user/service/SignUpService.java
@@ -1,0 +1,35 @@
+package com.ecolink.core.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.auth.domain.SocialAvatarCreateRequest;
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.avatar.service.AvatarService;
+import com.ecolink.core.avatar.service.NicknameService;
+import com.ecolink.core.avatar.service.ProfilePhotoService;
+import com.ecolink.core.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SignUpService {
+
+	private final UserService userService;
+	private final RoleService roleService;
+	private final AvatarService avatarService;
+	private final NicknameService nicknameService;
+	private final ProfilePhotoService profilePhotoService;
+
+	@Transactional
+	public User signUp(OAuth2Attributes attributes) {
+		User user = userService.createUser(attributes, roleService.getUserRole());
+		avatarService.createAvatar(SocialAvatarCreateRequest.of(
+			nicknameService.getUniqueRandomNickname(), user,
+			profilePhotoService.getInitialPhoto(attributes)));
+		return user;
+	}
+
+}

--- a/src/main/java/com/ecolink/core/user/service/UserService.java
+++ b/src/main/java/com/ecolink/core/user/service/UserService.java
@@ -1,0 +1,31 @@
+package com.ecolink.core.user.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ecolink.core.auth.domain.SocialUserCreateRequest;
+import com.ecolink.core.auth.model.OAuth2Attributes;
+import com.ecolink.core.user.domain.Role;
+import com.ecolink.core.user.domain.User;
+import com.ecolink.core.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public Optional<User> getOptionalByEmail(String email) {
+		return userRepository.findByEmail(email);
+	}
+
+	public User createUser(OAuth2Attributes attributes, Role role) {
+		return userRepository.save(User.createUser(SocialUserCreateRequest.of(attributes, role)));
+	}
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #21 

## ✨ PR 내용
- 회원가입 로직 추가
  - 랜덤 닉네임 선택 로직 추가
  - 기본 사진 선택 로직 추가
- 소셜 로그인 로직 추가
