### PR TITLE
[Feat] `GET /keywords/recent` API 추가

### DIFF
--- a/src/main/java/com/ecolink/core/avatar/service/AvatarService.java
+++ b/src/main/java/com/ecolink/core/avatar/service/AvatarService.java
@@ -32,9 +32,4 @@ public class AvatarService {
 	public Avatar createAvatar(AvatarCreateRequest request) {
 		return avatarRepository.save(Avatar.of(request));
 	}
-
-	public void checkAvatarExists(Long avatarId) {
-		if (avatarRepository.findById(avatarId).isEmpty())
-			throw new EntityNotFoundException(ErrorCode.AVATAR_NOT_FOUND);
-	}
 }

--- a/src/main/java/com/ecolink/core/store/controller/SearchHistoryController.java
+++ b/src/main/java/com/ecolink/core/store/controller/SearchHistoryController.java
@@ -2,17 +2,19 @@ package com.ecolink.core.store.controller;
 
 import java.util.List;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ecolink.core.auth.token.UserPrincipal;
 import com.ecolink.core.common.response.ApiResponse;
 import com.ecolink.core.store.dto.response.SearchHistoryDto;
 import com.ecolink.core.store.service.SearchHistoryService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -24,11 +26,13 @@ public class SearchHistoryController {
 	private final SearchHistoryService searchHistoryService;
 
 	@Tag(name = "${swagger.tag.search}")
-	@Operation(summary = "최근 검색어 조회 API",
-		description = "최근 검색어 조회 API")
+	@Operation(summary = "최근 검색어 조회 API - 인증 필요",
+		description = "최근 검색어 조회 API - 인증 필요",
+		security = {@SecurityRequirement(name = "session-token")})
+	@PreAuthorize("hasRole('USER')")
 	@GetMapping("/recent")
 	public ApiResponse<List<SearchHistoryDto>> getRecentKeywords(
-		@Parameter(description = "특정 아바타에 대한 최근 검색어를 조회하기 위한 아바타 ID") @RequestParam Long avatarId) {
-		return ApiResponse.ok(searchHistoryService.getSearchHistoryList(avatarId));
+		@AuthenticationPrincipal UserPrincipal principal) {
+		return ApiResponse.ok(searchHistoryService.getSearchHistoryList(principal.getAvatarId()));
 	}
 }

--- a/src/main/java/com/ecolink/core/store/controller/SearchHistoryController.java
+++ b/src/main/java/com/ecolink/core/store/controller/SearchHistoryController.java
@@ -1,0 +1,34 @@
+package com.ecolink.core.store.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecolink.core.common.response.ApiResponse;
+import com.ecolink.core.store.dto.response.SearchHistoryDto;
+import com.ecolink.core.store.service.SearchHistoryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("${api.prefix}/keywords")
+public class SearchHistoryController {
+
+	private final SearchHistoryService searchHistoryService;
+
+	@Tag(name = "${swagger.tag.search}")
+	@Operation(summary = "최근 검색어 조회 API",
+		description = "최근 검색어 조회 API")
+	@GetMapping("/recent")
+	public ApiResponse<List<SearchHistoryDto>> getRecentKeywords(
+		@Parameter(description = "특정 아바타에 대한 최근 검색어를 조회하기 위한 아바타 ID") @RequestParam Long avatarId) {
+		return ApiResponse.ok(searchHistoryService.getSearchHistoryList(avatarId));
+	}
+}

--- a/src/main/java/com/ecolink/core/store/dto/response/SearchHistoryDto.java
+++ b/src/main/java/com/ecolink/core/store/dto/response/SearchHistoryDto.java
@@ -1,0 +1,30 @@
+package com.ecolink.core.store.dto.response;
+
+import java.util.List;
+
+import com.ecolink.core.store.domain.SearchHistory;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchHistoryDto {
+
+	@Schema(description = "검색 히스토리 ID", example = "1")
+	private final Long id;
+
+	@Schema(description = "검색 키워드", example = "지구샵")
+	private final String keyword;
+
+	public SearchHistoryDto(SearchHistory searchHistory) {
+		this.id = searchHistory.getId();
+		this.keyword = searchHistory.getWord();
+	}
+
+	public static List<SearchHistoryDto> of(List<SearchHistory> searchHistories) {
+		return searchHistories.stream().map(SearchHistoryDto::new).toList();
+	}
+}

--- a/src/main/java/com/ecolink/core/store/dto/response/SearchHistoryDto.java
+++ b/src/main/java/com/ecolink/core/store/dto/response/SearchHistoryDto.java
@@ -1,7 +1,5 @@
 package com.ecolink.core.store.dto.response;
 
-import java.util.List;
-
 import com.ecolink.core.store.domain.SearchHistory;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -24,7 +22,7 @@ public class SearchHistoryDto {
 		this.keyword = searchHistory.getWord();
 	}
 
-	public static List<SearchHistoryDto> of(List<SearchHistory> searchHistories) {
-		return searchHistories.stream().map(SearchHistoryDto::new).toList();
+	public static SearchHistoryDto of(SearchHistory searchHistory) {
+		return new SearchHistoryDto(searchHistory);
 	}
 }

--- a/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
@@ -11,4 +11,6 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
 	List<SearchHistory> findByAvatarIdOrderByCreatedDateDesc(Long avatarId);
 
 	int countByAvatarId(Long avatarId);
+
+	SearchHistory findTopByAvatarIdOrderByCreatedDate(Long avatarId);
 }

--- a/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
@@ -12,5 +12,5 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
 
 	int countByAvatarId(Long avatarId);
 
-	SearchHistory findTopByAvatarIdOrderByCreatedDate(Long avatarId);
+	List<SearchHistory> findAllByAvatarIdOrderByCreatedDate(Long avatarId);
 }

--- a/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/ecolink/core/store/repository/SearchHistoryRepository.java
@@ -1,8 +1,14 @@
 package com.ecolink.core.store.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ecolink.core.store.domain.SearchHistory;
 
 public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+	List<SearchHistory> findByAvatarIdOrderByCreatedDateDesc(Long avatarId);
+
+	int countByAvatarId(Long avatarId);
 }

--- a/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
+++ b/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
@@ -24,11 +24,8 @@ public class SearchHistoryService {
 	public void saveSearchHistory(String keyword, Long avatarId) {
 		if (avatarId == null)
 			return;
-		if (searchHistoryRepository.countByAvatarId(avatarId) == 10) {
-			SearchHistory lastSearchHistory = searchHistoryRepository.findByAvatarIdOrderByCreatedDateDesc(avatarId)
-				.get(9);
-			searchHistoryRepository.delete(lastSearchHistory);
-		}
+		if (searchHistoryRepository.countByAvatarId(avatarId) == 10)
+			searchHistoryRepository.delete(searchHistoryRepository.findTopByAvatarIdOrderByCreatedDate(avatarId));
 		searchHistoryRepository.save(new SearchHistory(keyword, avatarService.getById(avatarId)));
 	}
 

--- a/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
+++ b/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
@@ -1,10 +1,13 @@
 package com.ecolink.core.store.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ecolink.core.avatar.service.AvatarService;
 import com.ecolink.core.store.domain.SearchHistory;
+import com.ecolink.core.store.dto.response.SearchHistoryDto;
 import com.ecolink.core.store.repository.SearchHistoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,15 @@ public class SearchHistoryService {
 	public void saveSearchHistory(String keyword, Long avatarId) {
 		if (avatarId == null)
 			return;
+		if (searchHistoryRepository.countByAvatarId(avatarId) == 10) {
+			SearchHistory lastSearchHistory = searchHistoryRepository.findByAvatarIdOrderByCreatedDateDesc(avatarId)
+				.get(9);
+			searchHistoryRepository.delete(lastSearchHistory);
+		}
 		searchHistoryRepository.save(new SearchHistory(keyword, avatarService.getById(avatarId)));
+	}
+
+	public List<SearchHistoryDto> getSearchHistoryList(Long avatarId) {
+		return SearchHistoryDto.of(searchHistoryRepository.findByAvatarIdOrderByCreatedDateDesc(avatarId));
 	}
 }

--- a/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
+++ b/src/main/java/com/ecolink/core/store/service/SearchHistoryService.java
@@ -30,6 +30,7 @@ public class SearchHistoryService {
 	}
 
 	public List<SearchHistoryDto> getSearchHistoryList(Long avatarId) {
+		avatarService.getById(avatarId);
 		return SearchHistoryDto.of(searchHistoryRepository.findByAvatarIdOrderByCreatedDateDesc(avatarId));
 	}
 }

--- a/src/main/java/com/ecolink/core/store/service/StoreSearchService.java
+++ b/src/main/java/com/ecolink/core/store/service/StoreSearchService.java
@@ -6,7 +6,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.ecolink.core.avatar.service.AvatarService;
 import com.ecolink.core.common.dto.CursorPage;
 import com.ecolink.core.store.domain.Store;
 import com.ecolink.core.store.dto.request.StoreSearchRequest;
@@ -25,7 +24,6 @@ public class StoreSearchService {
 	private final StoreService storeService;
 	private final StoreJpaRepository storeJpaRepository;
 	private final StoreProductService storeProductService;
-	private final AvatarService avatarService;
 	private final ApplicationEventPublisher eventPublisher;
 
 	public StoreDetailResponse getStoreDetailPage(Long id, Long avatarId) {
@@ -39,10 +37,6 @@ public class StoreSearchService {
 	}
 
 	public CursorPage<StoreSearchDto, Long> searchStores(StoreSearchRequest request, Long avatarId) {
-
-		if (avatarId != null)
-			avatarService.checkAvatarExists(avatarId);
-
 		List<StoreSearchDto> storeSearchDtos = storeJpaRepository.findStoresByKeyword(request, avatarId);
 
 		storeProductService.processAndLimitTop3Products(request, storeSearchDtos);


### PR DESCRIPTION
## 📌 관련 이슈
- #20 

## ✨ PR 내용
- 최근 검색어 조회 API 추가
- 아바타마다 최근 검색어 최대 10개까지만 저장할 수 있도록 기능 추가
    -  `SearchHistory` 삭제할 때는 생성일자가 제일 오래된 히스토리를 삭제

## 📚 레퍼런스 혹은 궁금한 사항들
- ~~`SearchHistoryController`에서 `avatarId`를 파라미터로 요청하고 있는데 옳은 방식인지 궁금합니다! (인증을 하지 않아도 되는지 궁금합니다!)~~ &rightarrow; 사용자 인증 필수로 추가했습니다!

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->