### PR TITLE
[Feat] `GET /my-page` 응답 필드 수정

### DIFF
--- a/src/main/java/com/ecolink/core/auth/dto/response/AuthenticationResponse.java
+++ b/src/main/java/com/ecolink/core/auth/dto/response/AuthenticationResponse.java
@@ -17,16 +17,16 @@ public class AuthenticationResponse {
 
 	private final String email;
 	private final String nickname;
-	private final ImageFile profilePhoto;
+	private final ImageFile photo;
 	private final Boolean isNewUser;
 	private final UserType type;
 
-	private AuthenticationResponse(String email, UserType type, String nickname, ImageFile profilePhoto,
+	private AuthenticationResponse(String email, UserType type, String nickname, ImageFile photo,
 		boolean isNewUser) {
 		this.email = email;
 		this.type = type;
 		this.nickname = nickname;
-		this.profilePhoto = profilePhoto;
+		this.photo = photo;
 		this.isNewUser = isNewUser;
 	}
 

--- a/src/main/java/com/ecolink/core/avatar/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/ecolink/core/avatar/dto/response/GetMyPageResponse.java
@@ -1,6 +1,7 @@
 package com.ecolink.core.avatar.dto.response;
 
 import com.ecolink.core.avatar.domain.Avatar;
+import com.ecolink.core.common.domain.ImageFile;
 import com.ecolink.core.user.domain.User;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -15,8 +16,8 @@ public record GetMyPageResponse(
 	String email,
 	@Schema(description = "닉네임", example = "김철수")
 	String nickname,
-	@Schema(description = "프로필 사진 URL", example = "https://www.~~~.com")
-	String photoUrl,
+	@Schema(description = "프로필 사진 URL")
+	ImageFile photo,
 	@Schema(description = "매니저 회원 여부", example = "false")
 	boolean isManager
 ) {
@@ -25,7 +26,7 @@ public record GetMyPageResponse(
 		return GetMyPageResponse.builder()
 			.email(user.getEmail())
 			.nickname(avatar.getNickname())
-			.photoUrl(avatar.getPhoto().getFile().getUrl())
+			.photo(avatar.getPhoto().getFile())
 			.isManager(isManager)
 			.build();
 	}

--- a/src/main/java/com/ecolink/core/common/domain/ImageFile.java
+++ b/src/main/java/com/ecolink/core/common/domain/ImageFile.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class ImageFile {
 
+	@Schema(description = "이미지 파일의 URL", example = "https://www.~~~.com")
 	@NotNull
 	private String url;
 
@@ -27,8 +29,10 @@ public class ImageFile {
 	@JsonIgnore
 	private Long byteSize;
 
+	@Schema(description = "이미지 파일의 width (픽셀 단위)", example = "320")
 	private Integer width;
 
+	@Schema(description = "이미지 파일의 height (픽셀 단위)", example = "320")
 	private Integer height;
 
 	private ImageFile(String url, String s3Key, Long byteSize, Integer width, Integer height) {


### PR DESCRIPTION
## 📌 관련 이슈
없음

## ✨ PR 내용
사진파일은 앞으로 응답용 DTO에서 `String` 타입인 URL을 직접 내보내는 대신 `ImageFile` 객체를 활용하는 것으로
통일할 것이라서 기존 API의 응답 DTO의 필드를 바꿨습니다. 그리고 스웨거 설명 어노테이션을 추가했습니다.

- String 에서 ImageFile 로 응답 타입 변경
- ImageFile 에 스웨거 어노테이션 추가

