### PR TITLE
[HotFix] 마이페이지 정보 조회 API `UserType` 필드 추가

### DIFF
--- a/src/main/java/com/ecolink/core/avatar/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/ecolink/core/avatar/dto/response/GetMyPageResponse.java
@@ -2,6 +2,7 @@ package com.ecolink.core.avatar.dto.response;
 
 import com.ecolink.core.avatar.domain.Avatar;
 import com.ecolink.core.common.domain.ImageFile;
+import com.ecolink.core.user.constant.UserType;
 import com.ecolink.core.user.domain.User;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -18,6 +19,8 @@ public record GetMyPageResponse(
 	String nickname,
 	@Schema(description = "프로필 사진 URL")
 	ImageFile photo,
+	@Schema(description = "유저가 가입한 플랫폼 종류 KAKAO, NAVER", example = "KAKAO")
+	UserType type,
 	@Schema(description = "매니저 회원 여부", example = "false")
 	boolean isManager
 ) {
@@ -27,6 +30,7 @@ public record GetMyPageResponse(
 			.email(user.getEmail())
 			.nickname(avatar.getNickname())
 			.photo(avatar.getPhoto().getFile())
+			.type(user.getUserType())
 			.isManager(isManager)
 			.build();
 	}


### PR DESCRIPTION
## 📌 관련 이슈
#25 

## ✨ PR 내용
- 기존 PR에 누락된 기능(마이페이지 정보에 `UserType` 정보 표시) 추가