### PR TITLE
[Feat] 로그아웃 URI 변경, 성공 핸들러 추가

### DIFF
--- a/src/main/java/com/ecolink/core/auth/handler/JsonLogoutSuccessHandler.java
+++ b/src/main/java/com/ecolink/core/auth/handler/JsonLogoutSuccessHandler.java
@@ -1,0 +1,33 @@
+package com.ecolink.core.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.ecolink.core.auth.service.JsonResponseMaker;
+import com.ecolink.core.auth.token.UserPrincipal;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class JsonLogoutSuccessHandler implements LogoutSuccessHandler {
+
+	private final JsonResponseMaker jsonResponseMaker;
+
+	@Override
+	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+		UserPrincipal principal = (UserPrincipal)authentication.getPrincipal();
+		log.info("User signed out: {}", principal.getEmail());
+		jsonResponseMaker.mapToJson(response, principal.getEmail());
+	}
+
+}

--- a/src/main/java/com/ecolink/core/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ecolink/core/auth/handler/OAuth2SuccessHandler.java
@@ -1,23 +1,17 @@
 package com.ecolink.core.auth.handler;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import com.ecolink.core.auth.dto.AuthenticationResult;
-import com.ecolink.core.auth.dto.response.AuthenticationResponse;
 import com.ecolink.core.auth.model.OAuth2Attributes;
 import com.ecolink.core.auth.service.AuthenticationService;
+import com.ecolink.core.auth.service.JsonResponseMaker;
 import com.ecolink.core.auth.service.SecurityContextService;
-import com.ecolink.core.common.response.ApiResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +26,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 	private final SecurityContextService securityContextService;
 	private final AuthenticationService authenticationService;
-	private final ObjectMapper mapper;
+	private final JsonResponseMaker jsonResponseMaker;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -43,18 +37,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		AuthenticationResult result = authenticationService.oauthSignIn(attributes, request);
 		log.info("User signed in: {}", result.getResponse());
 		securityContextService.saveToSecurityContext(result.getToken());
-		responseDto(response, result.getResponse());
-	}
-
-	private void responseDto(HttpServletResponse response, AuthenticationResponse dto) throws IOException {
-		String convertedDto = mapper.writeValueAsString(ApiResponse.ok(dto));
-
-		response.setStatus(HttpStatus.ACCEPTED.value());
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
-
-		PrintWriter writer = response.getWriter();
-		writer.write(convertedDto);
+		jsonResponseMaker.mapToJson(response, result.getResponse());
 	}
 
 }

--- a/src/main/java/com/ecolink/core/auth/service/JsonResponseMaker.java
+++ b/src/main/java/com/ecolink/core/auth/service/JsonResponseMaker.java
@@ -1,0 +1,33 @@
+package com.ecolink.core.auth.service;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import com.ecolink.core.common.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class JsonResponseMaker {
+
+	private final ObjectMapper mapper;
+
+	public void mapToJson(HttpServletResponse response, Object dto) throws IOException {
+		String convertedDto = mapper.writeValueAsString(ApiResponse.ok(dto));
+
+		response.setStatus(HttpStatus.ACCEPTED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+
+		PrintWriter writer = response.getWriter();
+		writer.write(convertedDto);
+	}
+}

--- a/src/main/java/com/ecolink/core/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/ecolink/core/common/config/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.ecolink.core.auth.handler.JsonLogoutSuccessHandler;
 import com.ecolink.core.auth.handler.OAuth2SuccessHandler;
 import com.ecolink.core.auth.service.OAuth2UserLoadingService;
 
@@ -28,12 +29,14 @@ public class SecurityConfig {
 	private static final String AUTHORIZATION_HEADER = "Authorization";
 	private final OAuth2SuccessHandler oauth2SuccessHandler;
 	private final OAuth2UserLoadingService oauth2UserLoadingService;
+	private final JsonLogoutSuccessHandler logoutSuccessHandler;
 	private final String apiPrefix;
 
 	public SecurityConfig(OAuth2SuccessHandler oauth2SuccessHandler, OAuth2UserLoadingService oauth2UserLoadingService,
-		@Value("${api.prefix}") String apiPrefix) {
+		JsonLogoutSuccessHandler logoutSuccessHandler, @Value("${api.prefix}") String apiPrefix) {
 		this.oauth2SuccessHandler = oauth2SuccessHandler;
 		this.oauth2UserLoadingService = oauth2UserLoadingService;
+		this.logoutSuccessHandler = logoutSuccessHandler;
 		this.apiPrefix = apiPrefix;
 	}
 
@@ -47,6 +50,8 @@ public class SecurityConfig {
 					.redirectionEndpoint(redirection -> redirection.baseUri(apiPrefix + "/oauth2/code"))
 					.userInfoEndpoint(userInfo -> userInfo.userService(oauth2UserLoadingService))
 					.successHandler(oauth2SuccessHandler))
+			.logout(logout -> logout.logoutUrl(apiPrefix + "/logout")
+				.logoutSuccessHandler(logoutSuccessHandler))
 			.headers(headers ->
 				headers.addHeaderWriter(
 					new XFrameOptionsHeaderWriter(XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)));


### PR DESCRIPTION
## 📌 관련 이슈
- #21

## ✨ PR 내용
- 로그아웃 URI에 `prefix` 추가 `/logout` -> `/api/v1/logout`
- 로그아웃 성공시 Json형식으로 응답하도록 `JsonLogoutSuccessHandler` 추가