### PR TITLE
[Feat] CORS 정책 변경

### DIFF
--- a/src/main/java/com/ecolink/core/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/ecolink/core/common/config/security/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
 
 	CorsConfigurationSource websiteConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://eco-link.netlify.app"));
+		configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://map2zero.com"));
 		configuration.setAllowedMethods(List.of("GET", "POST", "DELETE", "PUT", "PATCH"));
 		configuration.setAllowedHeaders(List.of(AUTHORIZATION_HEADER, "Content-Type"));
 		configuration.setExposedHeaders(List.of(AUTHORIZATION_HEADER));


### PR DESCRIPTION
## 📌 관련 이슈
- #110 

## ✨ PR 내용
- CORS 정책에 프론트엔드 정식 배포 도메인(https://map2zero.com) 허용 설정 추가
- 기존 Netlify 링크는 CORS 정책 에서 비허용