### PR TITLE
[Fix] 판매 중인 상품수만 표시하도록 픽스

### DIFF
--- a/src/main/java/com/ecolink/core/product/repository/StoreProductRepository.java
+++ b/src/main/java/com/ecolink/core/product/repository/StoreProductRepository.java
@@ -12,6 +12,11 @@ import com.ecolink.core.product.domain.StoreProduct;
 
 public interface StoreProductRepository extends JpaRepository<StoreProduct, Long> {
 
+	@Query("select count(s) from StoreProduct s "
+		   + "where s.store.id = :id "
+		   + "and s.onSale = true ")
+	long countOnSaleByStoreId(@Param("id") Long storeId);
+
 	@Query("select sp from StoreProduct sp "
 		   + "join fetch sp.product "
 		   + "join fetch sp.store s "

--- a/src/main/java/com/ecolink/core/product/service/StoreProductService.java
+++ b/src/main/java/com/ecolink/core/product/service/StoreProductService.java
@@ -113,4 +113,8 @@ public class StoreProductService {
 			.orElse(null);
 	}
 
+	public Long getProductOnSaleCount(Long storeId) {
+		return storeProductRepository.countOnSaleByStoreId(storeId);
+	}
+
 }

--- a/src/main/java/com/ecolink/core/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/ecolink/core/store/dto/response/StoreDetailResponse.java
@@ -37,8 +37,8 @@ public record StoreDetailResponse(
 	int reviewCnt,
 	@Schema(description = "매장 평점", example = "4.8")
 	double averageScore,
-	@Schema(description = "매장 상품 수", example = "30")
-	int storeProductCnt,
+	@Schema(description = "판매중인 상품 수", example = "30")
+	long storeProductCnt,
 	@Schema(description = "매장 주소")
 	Address address,
 	@Schema(description = "매장 사진")
@@ -51,7 +51,7 @@ public record StoreDetailResponse(
 	boolean isBookmarked
 ) {
 
-	public static StoreDetailResponse of(Store store, boolean isBookmarked) {
+	public static StoreDetailResponse of(Store store, Long productCnt, boolean isBookmarked) {
 		return StoreDetailResponse.builder()
 			.id(store.getId())
 			.name(store.getName())
@@ -62,7 +62,7 @@ public record StoreDetailResponse(
 			.naverMapUrl(store.getNaverMapUrl())
 			.bookmarkCnt(store.getBookmarkCnt())
 			.reviewCnt(store.getReviewCnt())
-			.storeProductCnt(store.getProductCnt())
+			.storeProductCnt(productCnt)
 			.averageScore(store.roundedAverageScore())
 			.address(store.getAddress())
 			.photos(store.getStorePhotos().stream()

--- a/src/main/java/com/ecolink/core/store/service/StoreSearchService.java
+++ b/src/main/java/com/ecolink/core/store/service/StoreSearchService.java
@@ -38,7 +38,8 @@ public class StoreSearchService {
 
 	public StoreDetailResponse getStoreDetailPage(Long storeId, Long avatarId) {
 		return StoreDetailResponse.of(storeService.getStoreGraphById(storeId),
-			bookmarkService.existsBookmark(avatarId, storeId));
+			storeProductService.getProductOnSaleCount(storeId),
+			avatarId != null && bookmarkService.existsBookmark(avatarId, storeId));
 	}
 
 	public CursorPage<StoreSearchDto, Long> searchStores(StoreSearchRequest request, Long avatarId) {


### PR DESCRIPTION
## 📌 관련 이슈
- #119 

## ✨ PR 내용
- 매장 제품수를 캐싱한 제품 수로 표시하는 대신 카운트 쿼리를 날려 매번 DB에 접근해 확인 하도록 변경
- avatarId가 null 일 경우 불필요한 쿼리가 나가지 않도록 수정